### PR TITLE
Malformed Input

### DIFF
--- a/Claytondus.AmazonMWS.Products/Model/MoneyType.cs
+++ b/Claytondus.AmazonMWS.Products/Model/MoneyType.cs
@@ -16,6 +16,7 @@
 
 
 using System;
+using System.Globalization;
 using System.Xml;
 using System.Xml.Serialization;
 using Claytondus.AmazonMWS.Runtime;
@@ -100,7 +101,7 @@ namespace Claytondus.AmazonMWS.Products.Model
         public override void WriteFragmentTo(IMwsWriter writer)
         {
             writer.Write("CurrencyCode", _currencyCode);
-            writer.Write("Amount", _amount);
+            writer.Write("Amount", _amount?.ToString("0.00", CultureInfo.InvariantCulture));
         }
 
         public override void WriteTo(IMwsWriter writer)

--- a/Claytondus.AmazonMWS.Products/Model/MoneyType.cs
+++ b/Claytondus.AmazonMWS.Products/Model/MoneyType.cs
@@ -101,7 +101,7 @@ namespace Claytondus.AmazonMWS.Products.Model
         public override void WriteFragmentTo(IMwsWriter writer)
         {
             writer.Write("CurrencyCode", _currencyCode);
-            writer.Write("Amount", _amount?.ToString("0.00", CultureInfo.InvariantCulture));
+            writer.Write("Amount", _amount?.ToString(CultureInfo.InvariantCulture));
         }
 
         public override void WriteTo(IMwsWriter writer)


### PR DESCRIPTION
Hi,
now i got the issue after come back again.

You need to recode the WriteFragmentTo in the Claytondus.AmazonMWS.Products.Model.MoneyType class.
With the german localization the ".ToString" function convert the decimal "Amount" -> 12.99M to 12,99 but amazon need the dot version 12.99 .

So you need to change :
writer.Write("Amount", _amount);

to

writer.Write("Amount", _amount?.ToString(CultureInfo.InvariantCulture));


and it works for EUR. Please test it also for USD account. I can't test this without a USD account